### PR TITLE
Handle `SIGINT` signal.

### DIFF
--- a/4-ajax/8-xhr-longpoll/longpoll.view/server.js
+++ b/4-ajax/8-xhr-longpoll/longpoll.view/server.js
@@ -73,4 +73,9 @@ if (!module.parent) {
   console.log('Сервер запущен на порту 8080');
 } else {
   exports.accept = accept;
+  
+  // close all waiting connections in order to get graceful reload
+  process.on('SIGINT', function() {
+    publish("");
+  });
 }


### PR DESCRIPTION
Please take a look at: http://pm2.keymetrics.io/docs/usage/signals-clean-restart/#cleaning-states-and-jobs

This event means that PM2 wants to stop server, we can't keep all connections anymore.