### PR TITLE
Расширение прототипа NodeList в новых Chrome

### DIFF
--- a/2-ui/1-document/4-traversing-dom/article.md
+++ b/2-ui/1-document/4-traversing-dom/article.md
@@ -120,7 +120,7 @@ elem.childNodes[0] === elem.firstChild
 elem.childNodes[elem.childNodes.length - 1] === elem.lastChild
 ```
 
-## Коллекции -- не массивы
+## Коллекции -- не массивы (depricated)
 
 DOM-коллекции, такие как `childNodes` и другие, которые мы увидим далее, не являются JavaScript-массивами.
 
@@ -134,6 +134,17 @@ elems.forEach(function(elem) { // нет такого метода!
 */!*
   /* ... */
 });
+```
+
+Для Chrome 59.0.3071
+
+```for(let key in document.documentElement.childNodes.__proto__) { alert(key) }
+// length
+// item
+// entries
+// forEach
+// keys
+// values
 ```
 
 Именно поэтому `childNodes` и называют "коллекция" или "псевдомассив".


### PR DESCRIPTION
В новом Chrome прототип NodeList стал богаче, теперь его можно перебирать с помощью forEarch