### PR TITLE
[proxy] Исправление ссылки (getPrototypeOf).

### DIFF
--- a/1-js/10-es-modern/14-proxy/article.md
+++ b/1-js/10-es-modern/14-proxy/article.md
@@ -326,7 +326,7 @@ alert( user.name ); // Ilya
 
 Полный список возможных функций-перехватчиков, которые может задавать `handler`:
 
-- [getPrototypeOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/has) -- перехватывает обращение к методу `getPrototypeOf`.
+- [getPrototypeOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getPrototypeOf) -- перехватывает обращение к методу `getPrototypeOf`.
 - [setPrototypeOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/setPrototypeOf) -- перехватывает обращение к методу `setPrototypeOf`.
 - [isExtensible](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/isExtensible) -- перехватывает обращение к методу `isExtensible`.
 - [preventExtensions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/preventExtensions) -- перехватывает обращение к методу `preventExtensions`.


### PR DESCRIPTION
Исправление ссылки на документацию для функции getPrototypeOf.