### PR TITLE
Firefox event fix

### DIFF
--- a/2-ui/3-event-details/3-mousemove-mouseover-mouseout-mouseenter-mouseleave/2-hoverintent/solution.view/hoverIntent.js
+++ b/2-ui/3-event-details/3-mousemove-mouseover-mouseout-mouseenter-mouseleave/2-hoverintent/solution.view/hoverIntent.js
@@ -64,7 +64,7 @@ function HoverIntent(options) {
     cTime = Date.now();
   }
   
-  function trackSpeed() {
+  function trackSpeed(event) {
 
     let speed;
     


### PR DESCRIPTION
Решение задачи не работает в Firefox (судя по комментариям с версии 52, вплоть до текущей 56). Функция trackSpeed() не имеет параметров, но использует объект event, который в Chrome/IE11 берется из замыкания, а в Firefox требует объявления trackSpeed(event).