### PR TITLE
Тест приведен в соответствие с условием задачи и предлагаемым решением

### DIFF
--- a/1-js/7-js-misc/1-class-instanceof/1-format-date-polymorphic/_js.view/test.js
+++ b/1-js/7-js-misc/1-class-instanceof/1-format-date-polymorphic/_js.view/test.js
@@ -3,8 +3,8 @@ describe("formatDate", function() {
     assert.equal(formatDate('2011-10-02'), "02.10.11");
   });
 
-  it("читает дату из числа 1234567890 (миллисекунды)", function() {
-    assert.equal(formatDate(1234567890), "15.01.70");
+  it("читает дату из числа 1234567890 (секунды)", function() {
+    assert.equal(formatDate(1234567890), "14.02.09");
   });
 
   it("читает дату из массива вида [гггг, м, д]", function() {


### PR DESCRIPTION
Была путаница секунды \ миллисекунды;
Различие: в условиях задачи и предлагаемом решении - секунды, в пояснении к тесту были указаны миллисекунды

Предыдущим исправлением #123 были решены внутренние проблемы теста, но осталось несоответствие теста задаче и предлагаемому решению.