### PR TITLE
Доработана функция, вычисляющая возраст

### DIFF
--- a/1-js/6-objects-more/4-descriptors-getters-setters/article.md
+++ b/1-js/6-objects-more/4-descriptors-getters-setters/article.md
@@ -265,8 +265,15 @@ function User(name, birthday) {
   // age будет высчитывать возраст по birthday
   Object.defineProperty(this, "age", {
     get: function() {
-      var todayYear = new Date().getFullYear();
-      return todayYear - this.birthday.getFullYear();
+      var today = new Date();
+      var yearDelta = today.getFullYear() - this.birthday.getFullYear();
+
+      if (today.getMonth() > this.birthday.getMonth() ||
+        (today.getMonth() === this.birthday.getMonth() && today.getDate() >= this.birthday.getDate())) {
+        return yearDelta;
+      }
+
+      return yearDelta - 1;      
     }
   });
 */!*


### PR DESCRIPTION
Используемая в примере функция, вычисляющая разность в годах, в общем случае некорректна.
Например, для даты рождения 31/12/2017 и текущей даты 01/01/2018 будет вычисляться возраст в 1 год.