### PR TITLE
assert.sameMembers replaced by assert.deepEqual

### DIFF
--- a/1-js/4-data-structures/8-array-methods/11-array-unique/_js.view/test.js
+++ b/1-js/4-data-structures/8-array-methods/11-array-unique/_js.view/test.js
@@ -4,12 +4,13 @@ describe("unique", function() {
       "харе", "харе", "кришна", "кришна", "8-()"
     ];
 
-    assert.sameMembers(unique(strings), ["кришна", "харе", "8-()"]);
+    assert.deepEqual(unique(strings), ["кришна", "харе", "8-()"]);
   });
 
   it("не изменяет исходный массив", function() {
     var strings = ["кришна", "кришна", "харе", "харе"];
     unique(strings);
-    assert.sameMembers(strings, ["кришна", "кришна", "харе", "харе"]);
+
+    assert.deepEqual(strings, ["кришна", "кришна", "харе", "харе"]);
   });
 });


### PR DESCRIPTION
"assert.sameMembers" method replaced by "assert.deepEqual" for correct array testing.

Signed-off-by: ArthurKa <arthur.katruk@gmail.com>